### PR TITLE
Fix -l, --geometry-count option

### DIFF
--- a/bin/geojsplit
+++ b/bin/geojsplit
@@ -178,7 +178,6 @@ function inputGeoJSON(filename) {
 
     var fileCount = 0,
         geometries = [],
-        geometryCount = 0,
         geographyCache = {};
 
     /* stream handler, parser, splitter */
@@ -192,14 +191,12 @@ function inputGeoJSON(filename) {
                         geographyCache[data.properties[argv.k]].push(data);
                     }
                 } else {
-                    if (geometryCount < argv.l) {
+                    if (geometries.length < argv.l) {
                         geometries.push(data);
-                        geometryCount++;
                     } else {
                         outputGeoJSON(geometries, file, fileCount);
                         fileCount++;
                         geometries = [data];
-                        geometryCount = 0;
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/woodb/geojsplit/issues/7.

### Steps to reproduce

1. Find a GeoJSON file with >1 feature
2. Split into separate files for each feature with `geojsplit --geometry-count 1`

### Expected behavior

1 file per feature.

### Actual behavior

2 files per feature.

### Fix

The bug comes from here: https://github.com/woodb/geojsplit/blob/a4344c416f2574d24ce66f87b110b1ed2ee29f6a/bin/geojsplit#L201-L202

The `geometries` array has a single entry, but we're setting `geometryCount` to 0.

This fixes the bug by removing the `geometryCount` variable and using `geometries.length` instead.